### PR TITLE
Take a better swing at class E

### DIFF
--- a/draft-iab-use-it-or-lose-it.md
+++ b/draft-iab-use-it-or-lose-it.md
@@ -588,9 +588,11 @@ making version-independent assumptions about the structure of the IPv4 header.
 Protocol identifiers or codepoints that are reserved for future use can be
 especially problematic.  Reserving values without attributing semantics to their
 use can result in diverse or conflicting semantics being attributed without any
-hope of interoperability.  An example of this is the "class E" address space in
-IPv4 {{?RFC0988}}, which was originally reserved in {{?RFC0791}} without
-assigning any semantics.
+hope of interoperability.  An example of this is the 224/3 "class E" address
+space in IPv4 {{?RFC0988}}. This space was originally reserved in {{?RFC0791}}
+without assigning any semantics and has since been partially reclaimed for use
+in multicast (224/4) or not successfully reclaimed for any purpose (240/4)
+{{?RFC0988}}.
 
 For protocols that can use negotiation to attribute semantics to values, it is
 possible that unused codepoints can be reclaimed for active use, though this

--- a/draft-iab-use-it-or-lose-it.md
+++ b/draft-iab-use-it-or-lose-it.md
@@ -591,7 +591,7 @@ use can result in diverse or conflicting semantics being attributed without any
 hope of interoperability.  An example of this is the 224/3 "class E" address
 space in IPv4 {{?RFC0988}}. This space was originally reserved in {{?RFC0791}}
 without assigning any semantics and has since been partially reclaimed for use
-in multicast (224/4) or not successfully reclaimed for any purpose (240/4)
+in multicast (224/4), but otherwise has not been successfully reclaimed for any purpose (240/4)
 {{?RFC0988}}.
 
 For protocols that can use negotiation to attribute semantics to values, it is


### PR DESCRIPTION
This adds a shade more nuance to the text, identifies the space and acknowledges the limited reclamation of 224/4.

I might speculate that the limited deployment scope of multicast has allowed the use of 224/4 to continue without widespread problems.  In comparison, attempts to use 240/4 for unicast are much more likely to encounter issues.  Anyone who uses that space for their own address would risk not being able to reach (or not being reachable from) a number of other hosts, even if the routing system accepted the route.

Closes #73.  Not completely; the ICMP feedback is useful, but I don't think that it is necessary to get into that level of detail.