### PR TITLE
Stronger disclaimer

### DIFF
--- a/draft-iab-use-it-or-lose-it.md
+++ b/draft-iab-use-it-or-lose-it.md
@@ -116,10 +116,11 @@ extensions and code-points.  {{other}} outlines several additional strategies
 that might aid in ensuring that protocol changes remain possible over time.
 
 The experience that informs this document is predominantly at "higher" layers of
-the network stack, in protocols that operate at very large scale and
-Internet-scale applications.  It is possible that these conclusions are less
-applicable to protocol deployments that have less scale and diversity, or
-operate under different constraints.
+the network stack, in protocols with limited numbers of participants.  Though
+similar issues are present in many protocols that operate at scale, the
+tradeoffs involved with applying some of the suggested techniques can be more
+complex when there are many participants, such as at the network layer or in
+routing systems.
 
 
 # Imperfect Implementations Limit Protocol Evolution {#implementations}


### PR DESCRIPTION
Joel Halpern suggested that we more forcibly disclaim some of the
techniques that are mentioned in the document.

On review, the GREASE section is clear enough about limited
applicability (and also efficacy), so I think we're OK there.  But
the disclaimer in the introduction could be tightened more.

Joel acknowledged that the problem exists, but that the tradeoffs
involved in applying various techniques are much more complex.  That's a
good angle on this.  I've tried to phrase that sentiment in my own
words.